### PR TITLE
Remove logistic request slot limit for Buffer & Requester types

### DIFF
--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -130,8 +130,6 @@ function createLogisticContainer(name, logistic_type)
 	p.logistic_mode = logistic_type
 	if logistic_type == "storage" then
 		p.max_logistic_slots = 1
-	elseif logistic_type == "buffer" or logistic_type == "requester" then
-		p.max_logistic_slots = 30
 	end
 	return p
 end


### PR DESCRIPTION
Factorio 1.1.0 allows unlimited logistic request slots for Buffer & Requester chests. Warehousing has historically mirrored what the vanilla chests do.

It's too bad this change wasn't mentioned in the changelog, or it would have been ready in the very first mod release for 1.1.

To-do before merge:
- [x] Verify intended behavior in-game