### PR TITLE
Fix no gravity building (same as chests)

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,27 @@
+
+if data.raw['container']['steel-chest'].surface_conditions ~= nil then
+    local containers = -- prototype type -> list[prototype name]
+    {
+      container = { "basic" },
+      ["logistic-container"] = { "passive-provider", "active-provider", "storage", "buffer", "requester" },
+    }
+    for t,l in pairs(containers) do
+        for _,n in pairs(l) do
+          data.raw[t]["warehouse-"..n].surface_conditions =
+          {
+            {
+              property = "gravity",
+              min = 0.1
+            }
+          }
+
+          data.raw[t]["storehouse-"..n].surface_conditions =
+          {
+            {
+              property = "gravity",
+              min = 0.1
+            }
+          }
+        end
+      end
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,27 +1,23 @@
+if data.raw["container"]["steel-chest"].surface_conditions ~= nil then
+	local containers = { -- prototype type -> list[prototype name]
+		container = {"basic"},
+		["logistic-container"] = {"passive-provider", "active-provider", "storage", "buffer", "requester"},
+	}
+	for t, l in pairs(containers) do
+		for _, n in pairs(l) do
+			data.raw[t]["warehouse-" .. n].surface_conditions = {
+				{
+					property = "gravity",
+					min = 0.1,
+				}
+			}
 
-if data.raw['container']['steel-chest'].surface_conditions ~= nil then
-    local containers = -- prototype type -> list[prototype name]
-    {
-      container = { "basic" },
-      ["logistic-container"] = { "passive-provider", "active-provider", "storage", "buffer", "requester" },
-    }
-    for t,l in pairs(containers) do
-        for _,n in pairs(l) do
-          data.raw[t]["warehouse-"..n].surface_conditions =
-          {
-            {
-              property = "gravity",
-              min = 0.1
-            }
-          }
-
-          data.raw[t]["storehouse-"..n].surface_conditions =
-          {
-            {
-              property = "gravity",
-              min = 0.1
-            }
-          }
-        end
-      end
+			data.raw[t]["storehouse-" .. n].surface_conditions = {
+				{
+					property = "gravity",
+					min = 0.1,
+				}
+			}
+		end
+	end
 end


### PR DESCRIPTION
Fixes #103 - Space age uses the data-updates to add this property to containers to stop them being built on the space station, so let's copy that

Need to test on a "base" game with no space-age (the no expansion executable) to see if the nil check allows warehousing to "detect" space age