### PR TITLE
Overhaul recipes to replace iron-stick with iron-chest and concrete

### DIFF
--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -25,8 +25,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "passive-provider-chest", amount = 5 },
-			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "passive-provider-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 25 },
 			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
@@ -39,8 +39,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "storage-chest", amount = 5 },
-			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "storage-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 25 },
 			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
@@ -53,8 +53,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "active-provider-chest", amount = 5 },
-			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "active-provider-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 25 },
 			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
@@ -67,8 +67,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "requester-chest", amount = 5 },
-			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "requester-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 25 },
 			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
@@ -81,8 +81,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "buffer-chest", amount = 5 },
-			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "buffer-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 25 },
 			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
@@ -108,8 +108,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "passive-provider-chest", amount = 2 },
-			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "passive-provider-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 10 },
 			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
@@ -122,8 +122,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "storage-chest", amount = 2 },
-			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "storage-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 10 },
 			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
@@ -136,8 +136,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "active-provider-chest", amount = 2 },
-			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "active-provider-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 10 },
 			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
@@ -150,8 +150,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "requester-chest", amount = 2 },
-			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "requester-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 10 },
 			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
@@ -164,8 +164,8 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "buffer-chest", amount = 2 },
-			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "buffer-chest", amount = 1 },
+			{ type = "item", name = "advanced-circuit", amount = 10 },
 			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -11,9 +11,9 @@ data:extend({
 		enabled = false,
 		ingredients =
 		{
-			{ type = "item", name = "steel-plate", amount = 200 },
+			{ type = "item", name = "steel-plate", amount = 150 },
 			{ type = "item", name = "stone-brick", amount = 40 },
-			{ type = "item", name = "iron-stick", amount = 85 },
+			{ type = "item", name = "iron-chest", amount = 40 },
 		},
 		energy_required = 30,
 		results = {{type="item", name="warehouse-basic", amount = 1}},
@@ -25,9 +25,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "passive-provider-chest", amount = 1 },
-			{ type = "item", name = "steel-plate", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 15 },
+			{ type = "item", name = "passive-provider-chest", amount = 5 },
+			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="warehouse-passive-provider", amount=1}},
@@ -39,9 +39,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "storage-chest", amount = 1 },
-			{ type = "item", name = "steel-plate", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 15 },
+			{ type = "item", name = "storage-chest", amount = 5 },
+			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="warehouse-storage", amount=1}},
@@ -53,9 +53,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "active-provider-chest", amount = 1 },
-			{ type = "item", name = "steel-plate", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 15 },
+			{ type = "item", name = "active-provider-chest", amount = 5 },
+			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="warehouse-active-provider", amount=1}},
@@ -67,9 +67,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "requester-chest", amount = 1 },
-			{ type = "item", name = "steel-plate", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 15 },
+			{ type = "item", name = "requester-chest", amount = 5 },
+			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="warehouse-requester", amount=1}},
@@ -81,9 +81,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "warehouse-basic", amount = 1 },
-			{ type = "item", name = "buffer-chest", amount = 1 },
-			{ type = "item", name = "steel-plate", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 15 },
+			{ type = "item", name = "buffer-chest", amount = 5 },
+			{ type = "item", name = "steel-plate", amount = 25 },
+			{ type = "item", name = "concrete", amount = 40 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="warehouse-buffer", amount=1}},
@@ -94,9 +94,9 @@ data:extend({
 		enabled = false,
 		ingredients =
 		{
-			{ type = "item", name = "steel-plate", amount = 50 },
+			{ type = "item", name = "steel-plate", amount = 40 },
 			{ type = "item", name = "stone-brick", amount = 10 },
-			{ type = "item", name = "iron-stick", amount = 16 },
+			{ type = "item", name = "iron-chest", amount = 10 },
 		},
 		energy_required = 30,
 		results = {{type="item", name="storehouse-basic", amount=1}},
@@ -108,8 +108,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "passive-provider-chest", amount = 1 },
-			{ type = "item", name = "iron-stick", amount = 4 },
+			{ type = "item", name = "passive-provider-chest", amount = 2 },
+			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="storehouse-passive-provider", amount=1}},
@@ -121,8 +122,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "storage-chest", amount = 1 },
-			{ type = "item", name = "iron-stick", amount = 4 },
+			{ type = "item", name = "storage-chest", amount = 2 },
+			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="storehouse-storage", amount=1}},
@@ -134,8 +136,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "active-provider-chest", amount = 1 },
-			{ type = "item", name = "iron-stick", amount = 4 },
+			{ type = "item", name = "active-provider-chest", amount = 2 },
+			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="storehouse-active-provider", amount=1}},
@@ -147,8 +150,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "requester-chest", amount = 1 },
-			{ type = "item", name = "iron-stick", amount = 4 },
+			{ type = "item", name = "requester-chest", amount = 2 },
+			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="storehouse-requester", amount=1}},
@@ -160,8 +164,9 @@ data:extend({
 		ingredients =
 		{
 			{ type = "item", name = "storehouse-basic", amount = 1 },
-			{ type = "item", name = "buffer-chest", amount = 1 },
-			{ type = "item", name = "iron-stick", amount = 4 },
+			{ type = "item", name = "buffer-chest", amount = 2 },
+			{ type = "item", name = "steel-plate", amount = 10 },
+			{ type = "item", name = "concrete", amount = 15 },
 		},
 		energy_required = 5,
 		results = {{type="item", name="storehouse-buffer", amount=1}},

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -60,7 +60,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "robotics" },
+		prerequisites = { "warehouse-research", "robotics", "concrete" },
 		unit =
 		{
 			count = 150,

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -60,7 +60,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "robotics", "concrete" },
+		prerequisites = { "warehouse-research", "robotics", "concrete", "advanced-circuit" },
 		unit =
 		{
 			count = 150,


### PR DESCRIPTION
This resolves #106, though I did go a bit further than what was 'spitballed' there. Since we need to change the recipe anyway if we want to eliminate iron-stick, might as well take another look at the recipe balance at the same time.

Milestone 0.7.0 might become 1.0.0; it depends on how big this recipe rebalance ends up "feeling" if it gets bikeshedded.

----

In Factorio 2.0, iron-stick is an unlockable recipe, not automatically available at the start of the game. Adding iron-stick to every early technology that wants to use it in the resulting recipes feels hacky (though the base game does this; no less than 4 technologies unlock the iron-stick recipe now).

Crafting basic warehouse & storehouse has a relatively unchanged total iron cost, but iron-stick and some of the steel-plate in their recipes have been replaced with iron-chest.

Logistic variants are now intentionally more costly to craft, requiring multiples of the logistic chests they are to emulate (instead of only one), adding concrete, and increasing the steel-plate count.

Concrete also added to warehouse-logistics-research-1 prerequisites. Note that no migration is added to retroactively apply this change; players who have already unlocked this technology will keep it, but can't craft any more logistic buildings until they unlock Concrete.

_My lore-based reason for adding concrete to logistic buildings is that they probably have some automated item handling inside that needs the smoother floor, and can't deal with the roughness of stone brick. In reality of course, the reason is wanting to bump the complexity and cost a little more in exchange for the convenience._