### PR TITLE
Solve the "robotics" technology problem by requiring both its children

### DIFF
--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -60,7 +60,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "robotics", "concrete", "advanced-circuit" },
+		prerequisites = { "warehouse-research", "construction-robotics", "logistic-robotics", "concrete" },
 		unit =
 		{
 			count = 150,


### PR DESCRIPTION
Warehouses are powerful enough, it's probably reasonable to make users spend a couple hundred extra science packs to get this functionality. It's also technically impossible to require Construction OR Logistic robot research, because of how Factorio's data model works. Choosing just one of the two would be purely arbitrary.

(Choosing to require both is also arbitrary, to be fair; but we have very few options available without making things all weird with Lua scripting.)

Resolves #112