### PR TITLE
Solve "robotics" prerequisite problem with a new setting + 8 strings

### DIFF
--- a/src/data-updates.lua
+++ b/src/data-updates.lua
@@ -21,3 +21,11 @@ if data.raw["container"]["steel-chest"].surface_conditions ~= nil then
 		end
 	end
 end
+
+local logistic_mode = settings.startup["Warehousing-logistic-research-requirement"].value
+if logistic_mode == "both" or logistic_mode == "construction" then
+	table.insert(data.raw["technology"]["warehouse-logistics-research-1"].prerequisites, "construction-robotics")
+end
+if logistic_mode == "both" or logistic_mode == "logistic" then
+	table.insert(data.raw["technology"]["warehouse-logistics-research-1"].prerequisites, "logistic-robotics")
+end

--- a/src/locale/en/locale.cfg
+++ b/src/locale/en/locale.cfg
@@ -63,8 +63,20 @@ warehouse-logistics-research=Logistics Warehousing
 Warehousing-copy-logistic-system=Match Logistic System research cost
 Warehousing-icon-scaling=Scale inventory icons
 Warehousing-sixteen-mode=Use 0.16 inventory sizes
+Warehousing-logistic-research-requirement=Required robotics research for Logistics Warehousing 1
 
 [mod-setting-description]
 Warehousing-copy-logistic-system=Bases the research cost of Logistics Warehousing 2 on the cost of Logistic System
 Warehousing-icon-scaling=Enlarges the icons displayed in alt-mode to cover the whole building
 Warehousing-sixteen-mode=Keep Warehouse and Storehouse capacities the same as they were in Factorio 0.16 (before Warehousing 0.2.0)
+Warehousing-logistic-research-requirement=Choose your technology prerequisites for Logistics Warehousing 1
+
+[string-mod-setting]
+Warehousing-logistic-research-requirement-construction=Construction robotics
+Warehousing-logistic-research-requirement-logistic=Logistic robotics
+Warehousing-logistic-research-requirement-both=Construction + Logistic
+
+[string-mod-setting-description]
+Warehousing-logistic-research-requirement-construction=Requires only Construction Robotics research to unlock Logistics Warehousing 1
+Warehousing-logistic-research-requirement-logistic=Requires only Logistic Robotics research to unlock Logistics Warehousing 1
+Warehousing-logistic-research-requirement-both=Requires both Construction & Logistic Robotics research to unlock Logistics Warehousing 1

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -60,7 +60,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "robotics", "concrete", "advanced-circuit" },
+		prerequisites = { "warehouse-research", "concrete", "advanced-circuit" },
 		unit =
 		{
 			count = 150,

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -16,7 +16,7 @@ data:extend({
 		name = "Warehousing-copy-logistic-system",
 		setting_type = "startup",
 		default_value = false,
-		order = 'c-a',
+		order = 'c-a[b]',
 	},
 	{
 		type = "bool-setting",
@@ -24,5 +24,13 @@ data:extend({
 		setting_type = "startup",
 		default_value = false,
 		order = 'c-b',
+	},
+	{
+		type = "string-setting",
+		name = "Warehousing-logistic-research-requirement",
+		setting_type = "startup",
+		allowed_values = {"construction", "logistic", "both"},
+		default_value = "both",
+		order = 'c-a[a]',
 	},
 })


### PR DESCRIPTION
This *is* the overengineered solution, an alternative to #113 that also resolves #112 but ✨ fancier ✨

During testing I became very annoyed to realize that there is no support for a `__TECHNOLOGY__name__` placeholder in localized strings, even though `__ENTITY__name__` and `__ITEM__name__` and some others exist. That would be really useful for strings like the ones I added that reference the names of research technologies (or indeed, a couple of the existing strings too).

Rich text seems to be supported in all the setting names/tooltips, but putting an icon of Logistics Warehousing 1 isn't very useful IMO.