### PR TITLE
`item_sounds` global was removed in Factorio 2.0.16

### DIFF
--- a/src/prototypes/item.lua
+++ b/src/prototypes/item.lua
@@ -7,6 +7,7 @@
 --]]
 
 ICONPATH = "__Warehousing__/graphics/icons/"
+local item_sounds = require("__base__.prototypes.item_sounds")
 
 data:extend({
 	{


### PR DESCRIPTION
Fixes #115