### PR TITLE
Item sounds is no longer a global

### DIFF
--- a/src/prototypes/item.lua
+++ b/src/prototypes/item.lua
@@ -8,6 +8,8 @@
 
 ICONPATH = "__Warehousing__/graphics/icons/"
 
+local item_sounds = require("__base__.prototypes.item_sounds")
+
 data:extend({
 	{
 		type = "item",


### PR DESCRIPTION
This seems to have quietly changed in 2.0.16
