### PR TITLE
Add trash slots to buffer & requester logistic buildings

### DIFF
--- a/src/prototypes/entity.lua
+++ b/src/prototypes/entity.lua
@@ -249,6 +249,9 @@ function createLogisticContainer(name, logistic_type)
 	if logistic_type == "storage" then
 		p.max_logistic_slots = 1
 	end
+	if logistic_type == "buffer" or logistic_type == "requester" then
+		p.trash_inventory_size = 20
+	end
 	return p
 end
 


### PR DESCRIPTION
Copying the base logistic chests' default of 20 slots works for me, since we also just leave the maximum logistic slots at default.

This might result in somewhat more cramped inventory GUIs for the two logistic building types, but I could find no way around that. Unlike the requests section, logistic trash slots do not become a scrollable pane when there's more than one row. Mods can't control this behavior (that is, without creating custom GUIs, which would be overkill).

Closes #119.

----

I'm including sample screenshots of the container GUIs here, with "Automatic" UI scale of 125% on my 16" 2560x1600 display:

<details>
<summary>Buffer storehouse GUI example</summary>

![image](https://github.com/user-attachments/assets/d0ace172-bc20-4d88-af07-6d79df1b347b)

</details>

<details>
<summary>Requester warehouse GUI example</summary>

![image](https://github.com/user-attachments/assets/72c69ea2-69ff-4de3-a0e5-2e4fa390cdd0)

</details>