### PR TITLE
Fix the robotics tech issue by making it dependent on a player placing a Roboport

### DIFF
--- a/src/locale/en/locale.cfg
+++ b/src/locale/en/locale.cfg
@@ -58,7 +58,7 @@ linked-storehouse=Bigger equivalent to a linked chest
 [technology-name]
 warehouse-research=Warehousing
 warehouse-logistics-research=Logistics Warehousing
-warehouse-gate-research-1=Logistics Warehousing Prerequisite Research
+warehouse-logistics-research-gate=Logistics Warehousing Prerequisites
 
 [mod-setting-name]
 Warehousing-copy-logistic-system=Match Logistic System research cost

--- a/src/locale/en/locale.cfg
+++ b/src/locale/en/locale.cfg
@@ -58,6 +58,7 @@ linked-storehouse=Bigger equivalent to a linked chest
 [technology-name]
 warehouse-research=Warehousing
 warehouse-logistics-research=Logistics Warehousing
+warehouse-gate-research-1=Logistics Warehousing Prerequisite Research
 
 [mod-setting-name]
 Warehousing-copy-logistic-system=Match Logistic System research cost

--- a/src/migrations/Warehousing_1.1.0.lua
+++ b/src/migrations/Warehousing_1.1.0.lua
@@ -1,0 +1,20 @@
+-- Migration for Warehousing 1.1.0, which added the roboport-based research gate
+-- for unlocking logistic variants.
+
+for _, force in pairs(game.forces) do
+	local research_gate = force.technologies["warehouse-logistics-research-gate"]
+	local dependent_tech = force.technologies["warehouse-logistics-research-1"]
+
+	if research_gate then
+		if dependent_tech and dependent_tech.researched then
+			research_gate.researched = true
+		else
+			for _, surface in pairs(game.surfaces) do
+				if #surface.find_entities_filtered({ name = "roboport", force = force }) > 0 then
+					research_gate.researched = true
+					break
+				end
+			end
+		end
+	end
+end

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -41,17 +41,6 @@ data:extend(
 		name = "warehouse-logistics-research-gate",
 		icon = ICONPATH.."warehouse-logistics-research-1.png",
 		icon_size = 256,
-		effects =
-		{
-			{
-				type = "unlock-recipe",
-				recipe = "storehouse-passive-provider",
-			},
-			{
-				type = "unlock-recipe",
-				recipe = "storehouse-storage",
-			},
-		},
 		research_trigger =
 		{
 			type = "build-entity",

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -38,6 +38,29 @@ data:extend(
 	},
 	{
 		type = "technology",
+		name = "warehouse-gate-research-1",
+		icon = ICONPATH.."warehouse-logistics-research-1.png",
+		icon_size = 256,
+		effects =
+		{
+			{
+				type = "unlock-recipe",
+				recipe = "storehouse-passive-provider",
+			},
+			{
+				type = "unlock-recipe",
+				recipe = "storehouse-storage",
+			},
+		},
+		research_trigger =
+		{
+			type = "craft-item",
+			item = "passive-provider-chest",
+			count = 1
+		}
+	},
+	{
+		type = "technology",
 		name = "warehouse-logistics-research-1",
 		icon = ICONPATH.."warehouse-logistics-research-1.png",
 		icon_size = 256,
@@ -60,7 +83,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "robotics", "concrete", "advanced-circuit" },
+		prerequisites = { "warehouse-research", "warehouse-gate-research-1", "concrete", "advanced-circuit" },
 		unit =
 		{
 			count = 150,

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -38,7 +38,7 @@ data:extend(
 	},
 	{
 		type = "technology",
-		name = "warehouse-gate-research-1",
+		name = "warehouse-logistics-research-gate",
 		icon = ICONPATH.."warehouse-logistics-research-1.png",
 		icon_size = 256,
 		effects =
@@ -83,7 +83,7 @@ data:extend(
 				recipe = "storehouse-storage",
 			},
 		},
-		prerequisites = { "warehouse-research", "warehouse-gate-research-1", "concrete", "advanced-circuit" },
+		prerequisites = { "warehouse-research", "warehouse-logistics-research-gate", "concrete", "advanced-circuit" },
 		unit =
 		{
 			count = 150,

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -54,9 +54,8 @@ data:extend(
 		},
 		research_trigger =
 		{
-			type = "craft-item",
-			item = "passive-provider-chest",
-			count = 1
+			type = "build-entity",
+			entity = "roboport"
 		}
 	},
 	{


### PR DESCRIPTION
Now that Factorio 2.0 allows you to gate research behind crafting an item, my proposal for the fix is to depend on the player making a requestor chest.

Even in this case, it's not a wasted item, as you need the chest to create the warehouse, and it proves the tech exists.

This was mainly a PoC, and a discussion, we can take this PR further if we're happy with the solution. We should probably also add in some migrations, that if you've unlocked warehousing you're probably unlocked the "prerequisite" tech (the gate)